### PR TITLE
Release v8.0.1 (21-06-2023)

### DIFF
--- a/.github/changelog-ci-config.yml
+++ b/.github/changelog-ci-config.yml
@@ -9,6 +9,7 @@ version_regex: 'v?([0-9]{1,2})+[.]+([0-9]{1,2})+[.]+([0-9]{1,2})\s\(\d{1,2}-\d{1
 exclude_labels:
   - bot
   - dependabot
+  - dependencies
   - ci
 group_config:
   - title: Bug Fixes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,9 @@
 
 version: 2
 updates:
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "nuget"
+    directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "daily"
       time: "23:00"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 # Version: v8.0.1 (21-06-2023)
-
 * [eaae19a](https://github.com/devFelicity/Bot-Frontend/commit/eaae19aee0eebeed80cd5bdb625fbe9f2d8db505): docs(changelog): trim unwanted lines [skip ci]
 * [b0fa1ad](https://github.com/devFelicity/Bot-Frontend/commit/b0fa1ad2cd85e33942a6f7cb8d04a04ae200ec5a): [Changelog CI] Add Changelog for Version v8.0.0 (21-06-2023)
 * [c29bd1d](https://github.com/devFelicity/Bot-Frontend/commit/c29bd1d838fef56c6fcc18a2678467e6ffce5210): ci(changelog): update dependabot settings to be ignored
@@ -15,100 +14,19 @@
 * [85c11cb](https://github.com/devFelicity/Bot-Frontend/commit/85c11cb6a004b33372399f38744939e1099d2bc2): Merge remote-tracking branch 'origin/develop' into develop
 * [6014cc0](https://github.com/devFelicity/Bot-Frontend/commit/6014cc025d003694311c403d1f002d33ac142844): feat(debug): add WSL support and commitizen
 * [f8ecc00](https://github.com/devFelicity/Bot-Frontend/commit/f8ecc004a6ac6e6b52c308536b8c4a165c139103): Bump Serilog from 2.12.0 to 3.0.0
-
-Bumps [Serilog](https://github.com/serilog/serilog) from 2.12.0 to 3.0.0.
-- [Release notes](https://github.com/serilog/serilog/releases)
-- [Changelog](https://github.com/serilog/serilog/blob/dev/CHANGES.md)
-- [Commits](https://github.com/serilog/serilog/compare/v2.12.0...v3.0.0)
-
----
-updated-dependencies:
-- dependency-name: Serilog
-  dependency-type: direct:production
-  update-type: version-update:semver-major
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [5da8076](https://github.com/devFelicity/Bot-Frontend/commit/5da807641c65b37c85be7f7f7b4c33e074a723f5): update changelog
 * [afd40ae](https://github.com/devFelicity/Bot-Frontend/commit/afd40aed2d32eadc322da548c573097f6554ca18): add color to logging
 * [9e32977](https://github.com/devFelicity/Bot-Frontend/commit/9e329776cf26b91055dd5a00d121d50dc100cc3c): String optimisations
 * [a634ed7](https://github.com/devFelicity/Bot-Frontend/commit/a634ed7cda149e0291cd26169a377ee8c8f361a8): Bump DotNetBungieAPI from 2.10.0 to 2.11.0
-
-Bumps [DotNetBungieAPI](https://github.com/EndGameGl/DotNetBungieAPI) from 2.10.0 to 2.11.0.
-- [Release notes](https://github.com/EndGameGl/DotNetBungieAPI/releases)
-- [Commits](https://github.com/EndGameGl/DotNetBungieAPI/commits)
-
----
-updated-dependencies:
-- dependency-name: DotNetBungieAPI
-  dependency-type: direct:production
-  update-type: version-update:semver-minor
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [fd75996](https://github.com/devFelicity/Bot-Frontend/commit/fd75996c76208fcb0caebbb18089b6e0542bbca8): Bump Fergun.Interactive from 1.7.1 to 1.7.2
-
-Bumps [Fergun.Interactive](https://github.com/d4n3436/Fergun.Interactive) from 1.7.1 to 1.7.2.
-- [Release notes](https://github.com/d4n3436/Fergun.Interactive/releases)
-- [Commits](https://github.com/d4n3436/Fergun.Interactive/compare/v1.7.1...v1.7.2)
-
----
-updated-dependencies:
-- dependency-name: Fergun.Interactive
-  dependency-type: direct:production
-  update-type: version-update:semver-patch
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [01b340e](https://github.com/devFelicity/Bot-Frontend/commit/01b340e9c254d720fc01e7fdb399f421819f30d2): docs: update .all-contributorsrc [skip ci]
 * [38f0e91](https://github.com/devFelicity/Bot-Frontend/commit/38f0e916bee4937ab246505a64528983d8186f70): docs: update README.md [skip ci]
 * [ee135b9](https://github.com/devFelicity/Bot-Frontend/commit/ee135b944a5243139a62f98073b64c5465282d28): Fix up readme
 * [66a74b0](https://github.com/devFelicity/Bot-Frontend/commit/66a74b09c861367bd2521e55717ef19b5cc56c3f): Bump Sentry.AspNetCore from 3.33.0 to 3.33.1
-
-Bumps [Sentry.AspNetCore](https://github.com/getsentry/sentry-dotnet) from 3.33.0 to 3.33.1.
-- [Release notes](https://github.com/getsentry/sentry-dotnet/releases)
-- [Changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md)
-- [Commits](https://github.com/getsentry/sentry-dotnet/compare/3.33.0...3.33.1)
-
----
-updated-dependencies:
-- dependency-name: Sentry.AspNetCore
-  dependency-type: direct:production
-  update-type: version-update:semver-patch
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [78c73e1](https://github.com/devFelicity/Bot-Frontend/commit/78c73e16d1527b658da0e82387b81434045aa7de): Update .all-contributorsrc [skip ci]
 * [6b7aab8](https://github.com/devFelicity/Bot-Frontend/commit/6b7aab8b39e73603ba32337e7dd2e335c424f0b3): Update README.md [skip ci]
 * [a20f1fa](https://github.com/devFelicity/Bot-Frontend/commit/a20f1fa9f0a0ceb90c7a1c22c76d08ab1296c240): Bump Microsoft.EntityFrameworkCore from 7.0.5 to 7.0.7
-
-Bumps [Microsoft.EntityFrameworkCore](https://github.com/dotnet/efcore) from 7.0.5 to 7.0.7.
-- [Release notes](https://github.com/dotnet/efcore/releases)
-- [Commits](https://github.com/dotnet/efcore/compare/v7.0.5...v7.0.7)
-
----
-updated-dependencies:
-- dependency-name: Microsoft.EntityFrameworkCore
-  dependency-type: direct:production
-  update-type: version-update:semver-patch
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [b384f0d](https://github.com/devFelicity/Bot-Frontend/commit/b384f0d6b14aef362501e22b1889c282ade8bcb8): Bump Sentry.Serilog from 3.33.0 to 3.33.1
-
-Bumps [Sentry.Serilog](https://github.com/getsentry/sentry-dotnet) from 3.33.0 to 3.33.1.
-- [Release notes](https://github.com/getsentry/sentry-dotnet/releases)
-- [Changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md)
-- [Commits](https://github.com/getsentry/sentry-dotnet/compare/3.33.0...3.33.1)
-
----
-updated-dependencies:
-- dependency-name: Sentry.Serilog
-  dependency-type: direct:production
-  update-type: version-update:semver-patch
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [773ac97](https://github.com/devFelicity/Bot-Frontend/commit/773ac97b8c41b9d53c1b0bbd72fece4a4e828b62): Fix LW weapons not appearing in crafted
 * [eeb1d2b](https://github.com/devFelicity/Bot-Frontend/commit/eeb1d2b0c2c197be0bdcaafe153451931fcc5cc2): update changelog
 * [c71e3cb](https://github.com/devFelicity/Bot-Frontend/commit/c71e3cb7776ea0ddd80f54a9fc68b819cc800f3e): fix incorrect urls in /support
@@ -130,19 +48,6 @@ Signed-off-by: dependabot[bot] <support@github.com>
 * [a633f18](https://github.com/devFelicity/Bot-Frontend/commit/a633f18aa5f2489439e322d5bb9d2abffe9bf51b): update changelog [skip ci]
 * [724494d](https://github.com/devFelicity/Bot-Frontend/commit/724494db4572160030ee939a798f9a4be20cc7f8): fix downgrade issue
 * [07c9ec2](https://github.com/devFelicity/Bot-Frontend/commit/07c9ec2067ec325230f0e088bad5cd943aa62633): Bump DotNetBungieAPI from 2.9.0 to 2.10.0
-
-Bumps [DotNetBungieAPI](https://github.com/EndGameGl/DotNetBungieAPI) from 2.9.0 to 2.10.0.
-- [Release notes](https://github.com/EndGameGl/DotNetBungieAPI/releases)
-- [Commits](https://github.com/EndGameGl/DotNetBungieAPI/commits)
-
----
-updated-dependencies:
-- dependency-name: DotNetBungieAPI
-  dependency-type: direct:production
-  update-type: version-update:semver-minor
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [7b41abb](https://github.com/devFelicity/Bot-Frontend/commit/7b41abb0c6c284214c834574b4d83030f07cea35): Update dependabot.yml [skip-ci]
 * [ddafacd](https://github.com/devFelicity/Bot-Frontend/commit/ddafacd171b26c0e6e08e359b25d2523b15d17de): docs: update .all-contributorsrc [skip ci]
 * [18caba9](https://github.com/devFelicity/Bot-Frontend/commit/18caba9f802b1e5239e134120c2e8d835f00d205): docs: update README.md [skip ci]
@@ -156,8 +61,6 @@ Signed-off-by: dependabot[bot] <support@github.com>
 * [18676b9](https://github.com/devFelicity/Bot-Frontend/commit/18676b9394d75a9132a667367e3e07020ca77820): fix pr update json
 * [8a01efa](https://github.com/devFelicity/Bot-Frontend/commit/8a01efa9e407a02e523013b605bbed913de55cde): Update github action
 * [33ed80f](https://github.com/devFelicity/Bot-Frontend/commit/33ed80f313e8159c4c5dda3b22bad0004eb1c0e0): Revert "Update github action"
-
-This reverts commit 6768cdb3f6980301038ee3e4cbf7eefa9d63a7e1.
 * [6768cdb](https://github.com/devFelicity/Bot-Frontend/commit/6768cdb3f6980301038ee3e4cbf7eefa9d63a7e1): Update github action
 * [900d729](https://github.com/devFelicity/Bot-Frontend/commit/900d729c5b9df70a8caa56da2840f52a37159186): Update changelog
 * [12d0910](https://github.com/devFelicity/Bot-Frontend/commit/12d091081a7327e6bda488b401f45a70c5e2813a): add paginator to /recipes
@@ -174,8 +77,6 @@ This reverts commit 6768cdb3f6980301038ee3e4cbf7eefa9d63a7e1.
 * [472055e](https://github.com/devFelicity/Bot-Frontend/commit/472055e08dad3d5ca62da17bdfe58678f186d74a): Update RecommendedRolls.cs
 * [bc39347](https://github.com/devFelicity/Bot-Frontend/commit/bc3934733a5487af1e6baf3fdbaed71ab4e1f6d9): add season of the deep craftables
 * [5d6458e](https://github.com/devFelicity/Bot-Frontend/commit/5d6458e989eecda1dd2bcb122d437f55a50360e0): fix case sensitive
-
-
 # Version: v8.0.0 (21-06-2023)
 * [f8ecc00](https://github.com/devFelicity/Bot-Frontend/commit/f8ecc004a6ac6e6b52c308536b8c4a165c139103): Bump Serilog from 2.12.0 to 3.0.0
 * [5da8076](https://github.com/devFelicity/Bot-Frontend/commit/5da807641c65b37c85be7f7f7b4c33e074a723f5): update changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,100 +1,18 @@
 # Version: v8.0.0 (21-06-2023)
-
 * [f8ecc00](https://github.com/devFelicity/Bot-Frontend/commit/f8ecc004a6ac6e6b52c308536b8c4a165c139103): Bump Serilog from 2.12.0 to 3.0.0
-
-Bumps [Serilog](https://github.com/serilog/serilog) from 2.12.0 to 3.0.0.
-- [Release notes](https://github.com/serilog/serilog/releases)
-- [Changelog](https://github.com/serilog/serilog/blob/dev/CHANGES.md)
-- [Commits](https://github.com/serilog/serilog/compare/v2.12.0...v3.0.0)
-
----
-updated-dependencies:
-- dependency-name: Serilog
-  dependency-type: direct:production
-  update-type: version-update:semver-major
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [5da8076](https://github.com/devFelicity/Bot-Frontend/commit/5da807641c65b37c85be7f7f7b4c33e074a723f5): update changelog
 * [afd40ae](https://github.com/devFelicity/Bot-Frontend/commit/afd40aed2d32eadc322da548c573097f6554ca18): add color to logging
 * [9e32977](https://github.com/devFelicity/Bot-Frontend/commit/9e329776cf26b91055dd5a00d121d50dc100cc3c): String optimisations
 * [a634ed7](https://github.com/devFelicity/Bot-Frontend/commit/a634ed7cda149e0291cd26169a377ee8c8f361a8): Bump DotNetBungieAPI from 2.10.0 to 2.11.0
-
-Bumps [DotNetBungieAPI](https://github.com/EndGameGl/DotNetBungieAPI) from 2.10.0 to 2.11.0.
-- [Release notes](https://github.com/EndGameGl/DotNetBungieAPI/releases)
-- [Commits](https://github.com/EndGameGl/DotNetBungieAPI/commits)
-
----
-updated-dependencies:
-- dependency-name: DotNetBungieAPI
-  dependency-type: direct:production
-  update-type: version-update:semver-minor
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [fd75996](https://github.com/devFelicity/Bot-Frontend/commit/fd75996c76208fcb0caebbb18089b6e0542bbca8): Bump Fergun.Interactive from 1.7.1 to 1.7.2
-
-Bumps [Fergun.Interactive](https://github.com/d4n3436/Fergun.Interactive) from 1.7.1 to 1.7.2.
-- [Release notes](https://github.com/d4n3436/Fergun.Interactive/releases)
-- [Commits](https://github.com/d4n3436/Fergun.Interactive/compare/v1.7.1...v1.7.2)
-
----
-updated-dependencies:
-- dependency-name: Fergun.Interactive
-  dependency-type: direct:production
-  update-type: version-update:semver-patch
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [01b340e](https://github.com/devFelicity/Bot-Frontend/commit/01b340e9c254d720fc01e7fdb399f421819f30d2): docs: update .all-contributorsrc [skip ci]
 * [38f0e91](https://github.com/devFelicity/Bot-Frontend/commit/38f0e916bee4937ab246505a64528983d8186f70): docs: update README.md [skip ci]
 * [ee135b9](https://github.com/devFelicity/Bot-Frontend/commit/ee135b944a5243139a62f98073b64c5465282d28): Fix up readme
 * [66a74b0](https://github.com/devFelicity/Bot-Frontend/commit/66a74b09c861367bd2521e55717ef19b5cc56c3f): Bump Sentry.AspNetCore from 3.33.0 to 3.33.1
-
-Bumps [Sentry.AspNetCore](https://github.com/getsentry/sentry-dotnet) from 3.33.0 to 3.33.1.
-- [Release notes](https://github.com/getsentry/sentry-dotnet/releases)
-- [Changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md)
-- [Commits](https://github.com/getsentry/sentry-dotnet/compare/3.33.0...3.33.1)
-
----
-updated-dependencies:
-- dependency-name: Sentry.AspNetCore
-  dependency-type: direct:production
-  update-type: version-update:semver-patch
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [78c73e1](https://github.com/devFelicity/Bot-Frontend/commit/78c73e16d1527b658da0e82387b81434045aa7de): Update .all-contributorsrc [skip ci]
 * [6b7aab8](https://github.com/devFelicity/Bot-Frontend/commit/6b7aab8b39e73603ba32337e7dd2e335c424f0b3): Update README.md [skip ci]
 * [a20f1fa](https://github.com/devFelicity/Bot-Frontend/commit/a20f1fa9f0a0ceb90c7a1c22c76d08ab1296c240): Bump Microsoft.EntityFrameworkCore from 7.0.5 to 7.0.7
-
-Bumps [Microsoft.EntityFrameworkCore](https://github.com/dotnet/efcore) from 7.0.5 to 7.0.7.
-- [Release notes](https://github.com/dotnet/efcore/releases)
-- [Commits](https://github.com/dotnet/efcore/compare/v7.0.5...v7.0.7)
-
----
-updated-dependencies:
-- dependency-name: Microsoft.EntityFrameworkCore
-  dependency-type: direct:production
-  update-type: version-update:semver-patch
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [b384f0d](https://github.com/devFelicity/Bot-Frontend/commit/b384f0d6b14aef362501e22b1889c282ade8bcb8): Bump Sentry.Serilog from 3.33.0 to 3.33.1
-
-Bumps [Sentry.Serilog](https://github.com/getsentry/sentry-dotnet) from 3.33.0 to 3.33.1.
-- [Release notes](https://github.com/getsentry/sentry-dotnet/releases)
-- [Changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md)
-- [Commits](https://github.com/getsentry/sentry-dotnet/compare/3.33.0...3.33.1)
-
----
-updated-dependencies:
-- dependency-name: Sentry.Serilog
-  dependency-type: direct:production
-  update-type: version-update:semver-patch
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [773ac97](https://github.com/devFelicity/Bot-Frontend/commit/773ac97b8c41b9d53c1b0bbd72fece4a4e828b62): Fix LW weapons not appearing in crafted
 * [eeb1d2b](https://github.com/devFelicity/Bot-Frontend/commit/eeb1d2b0c2c197be0bdcaafe153451931fcc5cc2): update changelog
 * [c71e3cb](https://github.com/devFelicity/Bot-Frontend/commit/c71e3cb7776ea0ddd80f54a9fc68b819cc800f3e): fix incorrect urls in /support
@@ -116,19 +34,6 @@ Signed-off-by: dependabot[bot] <support@github.com>
 * [a633f18](https://github.com/devFelicity/Bot-Frontend/commit/a633f18aa5f2489439e322d5bb9d2abffe9bf51b): update changelog [skip ci]
 * [724494d](https://github.com/devFelicity/Bot-Frontend/commit/724494db4572160030ee939a798f9a4be20cc7f8): fix downgrade issue
 * [07c9ec2](https://github.com/devFelicity/Bot-Frontend/commit/07c9ec2067ec325230f0e088bad5cd943aa62633): Bump DotNetBungieAPI from 2.9.0 to 2.10.0
-
-Bumps [DotNetBungieAPI](https://github.com/EndGameGl/DotNetBungieAPI) from 2.9.0 to 2.10.0.
-- [Release notes](https://github.com/EndGameGl/DotNetBungieAPI/releases)
-- [Commits](https://github.com/EndGameGl/DotNetBungieAPI/commits)
-
----
-updated-dependencies:
-- dependency-name: DotNetBungieAPI
-  dependency-type: direct:production
-  update-type: version-update:semver-minor
-...
-
-Signed-off-by: dependabot[bot] <support@github.com>
 * [7b41abb](https://github.com/devFelicity/Bot-Frontend/commit/7b41abb0c6c284214c834574b4d83030f07cea35): Update dependabot.yml [skip-ci]
 * [ddafacd](https://github.com/devFelicity/Bot-Frontend/commit/ddafacd171b26c0e6e08e359b25d2523b15d17de): docs: update .all-contributorsrc [skip ci]
 * [18caba9](https://github.com/devFelicity/Bot-Frontend/commit/18caba9f802b1e5239e134120c2e8d835f00d205): docs: update README.md [skip ci]
@@ -142,8 +47,6 @@ Signed-off-by: dependabot[bot] <support@github.com>
 * [18676b9](https://github.com/devFelicity/Bot-Frontend/commit/18676b9394d75a9132a667367e3e07020ca77820): fix pr update json
 * [8a01efa](https://github.com/devFelicity/Bot-Frontend/commit/8a01efa9e407a02e523013b605bbed913de55cde): Update github action
 * [33ed80f](https://github.com/devFelicity/Bot-Frontend/commit/33ed80f313e8159c4c5dda3b22bad0004eb1c0e0): Revert "Update github action"
-
-This reverts commit 6768cdb3f6980301038ee3e4cbf7eefa9d63a7e1.
 * [6768cdb](https://github.com/devFelicity/Bot-Frontend/commit/6768cdb3f6980301038ee3e4cbf7eefa9d63a7e1): Update github action
 * [900d729](https://github.com/devFelicity/Bot-Frontend/commit/900d729c5b9df70a8caa56da2840f52a37159186): Update changelog
 * [12d0910](https://github.com/devFelicity/Bot-Frontend/commit/12d091081a7327e6bda488b401f45a70c5e2813a): add paginator to /recipes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,181 @@
+# Version: v8.0.1 (21-06-2023)
+
+* [eaae19a](https://github.com/devFelicity/Bot-Frontend/commit/eaae19aee0eebeed80cd5bdb625fbe9f2d8db505): docs(changelog): trim unwanted lines [skip ci]
+* [b0fa1ad](https://github.com/devFelicity/Bot-Frontend/commit/b0fa1ad2cd85e33942a6f7cb8d04a04ae200ec5a): [Changelog CI] Add Changelog for Version v8.0.0 (21-06-2023)
+* [c29bd1d](https://github.com/devFelicity/Bot-Frontend/commit/c29bd1d838fef56c6fcc18a2678467e6ffce5210): ci(changelog): update dependabot settings to be ignored
+* [df18cdf](https://github.com/devFelicity/Bot-Frontend/commit/df18cdf2303a023c101defdab70ee34ba90e57e4): ci(changelog): force re-generation with new settings
+* [2a3aa14](https://github.com/devFelicity/Bot-Frontend/commit/2a3aa147a41ab95044a16eab529a4a8b26bfdbf1): ci(changelog): trim unwanted lines
+* [91426ae](https://github.com/devFelicity/Bot-Frontend/commit/91426ae235c83a447432bfd59400f3e1db6e46b9): [Changelog CI] Add Changelog for Version v8.0.0 (21-06-2023)
+* [c127caa](https://github.com/devFelicity/Bot-Frontend/commit/c127caad2974686a2bf8fa1a7fd24eae9fb2f3c1): ci(changelog): remove auto-publisher (will re-add later if I don't forget)
+* [e84dd70](https://github.com/devFelicity/Bot-Frontend/commit/e84dd7036ba1ae46788687688d9c21feb0aa2233): ci(changelog): typo in config file name
+* [a31b2cd](https://github.com/devFelicity/Bot-Frontend/commit/a31b2cdc65e3288e255c0c69512de92ad85638f2): ci(changelog): delete changelog.md
+* [c9d0e10](https://github.com/devFelicity/Bot-Frontend/commit/c9d0e104a7268ba841edbc92fb261d080155fc90): ci(changelog): remove old busted changelog CI
+* [fa42235](https://github.com/devFelicity/Bot-Frontend/commit/fa422350f3421f99365d54022330c33aa44324be): feat(rollfinder): add support for new layout
+* [4a94b22](https://github.com/devFelicity/Bot-Frontend/commit/4a94b228fcdf4e6899dee68afb680a0f4808c1fe): style(main): auto-cleanup
+* [85c11cb](https://github.com/devFelicity/Bot-Frontend/commit/85c11cb6a004b33372399f38744939e1099d2bc2): Merge remote-tracking branch 'origin/develop' into develop
+* [6014cc0](https://github.com/devFelicity/Bot-Frontend/commit/6014cc025d003694311c403d1f002d33ac142844): feat(debug): add WSL support and commitizen
+* [f8ecc00](https://github.com/devFelicity/Bot-Frontend/commit/f8ecc004a6ac6e6b52c308536b8c4a165c139103): Bump Serilog from 2.12.0 to 3.0.0
+
+Bumps [Serilog](https://github.com/serilog/serilog) from 2.12.0 to 3.0.0.
+- [Release notes](https://github.com/serilog/serilog/releases)
+- [Changelog](https://github.com/serilog/serilog/blob/dev/CHANGES.md)
+- [Commits](https://github.com/serilog/serilog/compare/v2.12.0...v3.0.0)
+
+---
+updated-dependencies:
+- dependency-name: Serilog
+  dependency-type: direct:production
+  update-type: version-update:semver-major
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [5da8076](https://github.com/devFelicity/Bot-Frontend/commit/5da807641c65b37c85be7f7f7b4c33e074a723f5): update changelog
+* [afd40ae](https://github.com/devFelicity/Bot-Frontend/commit/afd40aed2d32eadc322da548c573097f6554ca18): add color to logging
+* [9e32977](https://github.com/devFelicity/Bot-Frontend/commit/9e329776cf26b91055dd5a00d121d50dc100cc3c): String optimisations
+* [a634ed7](https://github.com/devFelicity/Bot-Frontend/commit/a634ed7cda149e0291cd26169a377ee8c8f361a8): Bump DotNetBungieAPI from 2.10.0 to 2.11.0
+
+Bumps [DotNetBungieAPI](https://github.com/EndGameGl/DotNetBungieAPI) from 2.10.0 to 2.11.0.
+- [Release notes](https://github.com/EndGameGl/DotNetBungieAPI/releases)
+- [Commits](https://github.com/EndGameGl/DotNetBungieAPI/commits)
+
+---
+updated-dependencies:
+- dependency-name: DotNetBungieAPI
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [fd75996](https://github.com/devFelicity/Bot-Frontend/commit/fd75996c76208fcb0caebbb18089b6e0542bbca8): Bump Fergun.Interactive from 1.7.1 to 1.7.2
+
+Bumps [Fergun.Interactive](https://github.com/d4n3436/Fergun.Interactive) from 1.7.1 to 1.7.2.
+- [Release notes](https://github.com/d4n3436/Fergun.Interactive/releases)
+- [Commits](https://github.com/d4n3436/Fergun.Interactive/compare/v1.7.1...v1.7.2)
+
+---
+updated-dependencies:
+- dependency-name: Fergun.Interactive
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [01b340e](https://github.com/devFelicity/Bot-Frontend/commit/01b340e9c254d720fc01e7fdb399f421819f30d2): docs: update .all-contributorsrc [skip ci]
+* [38f0e91](https://github.com/devFelicity/Bot-Frontend/commit/38f0e916bee4937ab246505a64528983d8186f70): docs: update README.md [skip ci]
+* [ee135b9](https://github.com/devFelicity/Bot-Frontend/commit/ee135b944a5243139a62f98073b64c5465282d28): Fix up readme
+* [66a74b0](https://github.com/devFelicity/Bot-Frontend/commit/66a74b09c861367bd2521e55717ef19b5cc56c3f): Bump Sentry.AspNetCore from 3.33.0 to 3.33.1
+
+Bumps [Sentry.AspNetCore](https://github.com/getsentry/sentry-dotnet) from 3.33.0 to 3.33.1.
+- [Release notes](https://github.com/getsentry/sentry-dotnet/releases)
+- [Changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md)
+- [Commits](https://github.com/getsentry/sentry-dotnet/compare/3.33.0...3.33.1)
+
+---
+updated-dependencies:
+- dependency-name: Sentry.AspNetCore
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [78c73e1](https://github.com/devFelicity/Bot-Frontend/commit/78c73e16d1527b658da0e82387b81434045aa7de): Update .all-contributorsrc [skip ci]
+* [6b7aab8](https://github.com/devFelicity/Bot-Frontend/commit/6b7aab8b39e73603ba32337e7dd2e335c424f0b3): Update README.md [skip ci]
+* [a20f1fa](https://github.com/devFelicity/Bot-Frontend/commit/a20f1fa9f0a0ceb90c7a1c22c76d08ab1296c240): Bump Microsoft.EntityFrameworkCore from 7.0.5 to 7.0.7
+
+Bumps [Microsoft.EntityFrameworkCore](https://github.com/dotnet/efcore) from 7.0.5 to 7.0.7.
+- [Release notes](https://github.com/dotnet/efcore/releases)
+- [Commits](https://github.com/dotnet/efcore/compare/v7.0.5...v7.0.7)
+
+---
+updated-dependencies:
+- dependency-name: Microsoft.EntityFrameworkCore
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [b384f0d](https://github.com/devFelicity/Bot-Frontend/commit/b384f0d6b14aef362501e22b1889c282ade8bcb8): Bump Sentry.Serilog from 3.33.0 to 3.33.1
+
+Bumps [Sentry.Serilog](https://github.com/getsentry/sentry-dotnet) from 3.33.0 to 3.33.1.
+- [Release notes](https://github.com/getsentry/sentry-dotnet/releases)
+- [Changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md)
+- [Commits](https://github.com/getsentry/sentry-dotnet/compare/3.33.0...3.33.1)
+
+---
+updated-dependencies:
+- dependency-name: Sentry.Serilog
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [773ac97](https://github.com/devFelicity/Bot-Frontend/commit/773ac97b8c41b9d53c1b0bbd72fece4a4e828b62): Fix LW weapons not appearing in crafted
+* [eeb1d2b](https://github.com/devFelicity/Bot-Frontend/commit/eeb1d2b0c2c197be0bdcaafe153451931fcc5cc2): update changelog
+* [c71e3cb](https://github.com/devFelicity/Bot-Frontend/commit/c71e3cb7776ea0ddd80f54a9fc68b819cc800f3e): fix incorrect urls in /support
+* [6aad3c5](https://github.com/devFelicity/Bot-Frontend/commit/6aad3c50d782efe84d588589ca5a04b9a7539ef1): fix dupe in crafted weapons
+* [5c5726c](https://github.com/devFelicity/Bot-Frontend/commit/5c5726c8dbf08365e0210fe615cd06096b273a14): Update README.md [skip ci]
+* [b11d536](https://github.com/devFelicity/Bot-Frontend/commit/b11d536fee872bb3ef3f0584df698c920b7ff7ab): Update FUNDING.yml [skip ci]
+* [f9c57fb](https://github.com/devFelicity/Bot-Frontend/commit/f9c57fb44edbaecc8caf0edd9a3a289ca62ae8cc): push changelog
+* [7c141bb](https://github.com/devFelicity/Bot-Frontend/commit/7c141bb90c62a43cdab4b5b3f74d2cafe0a3b57e): cleanup
+* [f10c602](https://github.com/devFelicity/Bot-Frontend/commit/f10c602c389e93ef8a8b7abade07413a564edac2): Remove redundant code
+* [abb0d34](https://github.com/devFelicity/Bot-Frontend/commit/abb0d34ced01dcfe8f25982e0a1f3224702fea33): Re-add showAll on /recipes
+* [cb6c690](https://github.com/devFelicity/Bot-Frontend/commit/cb6c6905d11c0227435a9e42625d3ec08b366725): correct Ada-1 description
+* [5a07114](https://github.com/devFelicity/Bot-Frontend/commit/5a07114340c9628518a33fef886f1cc7924cc30b): Added count to rarest emblems
+* [04e06b3](https://github.com/devFelicity/Bot-Frontend/commit/04e06b3de6bb6f1e303d75501d4c84b5fabaf4be): missed link change
+* [ad4f3bb](https://github.com/devFelicity/Bot-Frontend/commit/ad4f3bb29326cdcaa80c6a4b929762abd798d9d1): bump dependencies
+* [099c2f2](https://github.com/devFelicity/Bot-Frontend/commit/099c2f29487dc8b06bbbd697c140dffd99f0ce1c): add self-hosted assets
+* [cb0275e](https://github.com/devFelicity/Bot-Frontend/commit/cb0275e5cbe446e2c2f9357cba4b774d054c61e4): add support message
+* [7d886f8](https://github.com/devFelicity/Bot-Frontend/commit/7d886f8163de306f98f1584f7f6b1fcb7ef9d797): added GotD loot table
+* [ebe4ab3](https://github.com/devFelicity/Bot-Frontend/commit/ebe4ab34f9a5ec17ed9b811dd107a655b5cc0e7b): Fix new version issues
+* [a633f18](https://github.com/devFelicity/Bot-Frontend/commit/a633f18aa5f2489439e322d5bb9d2abffe9bf51b): update changelog [skip ci]
+* [724494d](https://github.com/devFelicity/Bot-Frontend/commit/724494db4572160030ee939a798f9a4be20cc7f8): fix downgrade issue
+* [07c9ec2](https://github.com/devFelicity/Bot-Frontend/commit/07c9ec2067ec325230f0e088bad5cd943aa62633): Bump DotNetBungieAPI from 2.9.0 to 2.10.0
+
+Bumps [DotNetBungieAPI](https://github.com/EndGameGl/DotNetBungieAPI) from 2.9.0 to 2.10.0.
+- [Release notes](https://github.com/EndGameGl/DotNetBungieAPI/releases)
+- [Commits](https://github.com/EndGameGl/DotNetBungieAPI/commits)
+
+---
+updated-dependencies:
+- dependency-name: DotNetBungieAPI
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [7b41abb](https://github.com/devFelicity/Bot-Frontend/commit/7b41abb0c6c284214c834574b4d83030f07cea35): Update dependabot.yml [skip-ci]
+* [ddafacd](https://github.com/devFelicity/Bot-Frontend/commit/ddafacd171b26c0e6e08e359b25d2523b15d17de): docs: update .all-contributorsrc [skip ci]
+* [18caba9](https://github.com/devFelicity/Bot-Frontend/commit/18caba9f802b1e5239e134120c2e8d835f00d205): docs: update README.md [skip ci]
+* [1405d98](https://github.com/devFelicity/Bot-Frontend/commit/1405d98adaf4704139ebce63ef66819542fd69f3): Update .all-contributorsrc
+* [cce0775](https://github.com/devFelicity/Bot-Frontend/commit/cce0775218a1acda390a63132b958a8da1dd7cd4): hopefully fixes cpu loop
+* [9a3c95c](https://github.com/devFelicity/Bot-Frontend/commit/9a3c95c2796e84abad2aa6dd9c73660f650bcdc4): forgor changelog
+* [0c71112](https://github.com/devFelicity/Bot-Frontend/commit/0c71112609df879e795f0064118fd6384e101602): Update to new auth url (also using as test)
+* [079fc25](https://github.com/devFelicity/Bot-Frontend/commit/079fc251e39d528676b7cf974e627c38ff8df4b6): use jq to make a payload
+* [f598f0d](https://github.com/devFelicity/Bot-Frontend/commit/f598f0d47c7b9e1fc7e224d99ee2c3c6b9fdd47c): attempt 412323234 at getting commit list to work
+* [f2eb7fa](https://github.com/devFelicity/Bot-Frontend/commit/f2eb7fa4f4aa9b3025f45e4edabd299700d239fd): quote marks are weird
+* [18676b9](https://github.com/devFelicity/Bot-Frontend/commit/18676b9394d75a9132a667367e3e07020ca77820): fix pr update json
+* [8a01efa](https://github.com/devFelicity/Bot-Frontend/commit/8a01efa9e407a02e523013b605bbed913de55cde): Update github action
+* [33ed80f](https://github.com/devFelicity/Bot-Frontend/commit/33ed80f313e8159c4c5dda3b22bad0004eb1c0e0): Revert "Update github action"
+
+This reverts commit 6768cdb3f6980301038ee3e4cbf7eefa9d63a7e1.
+* [6768cdb](https://github.com/devFelicity/Bot-Frontend/commit/6768cdb3f6980301038ee3e4cbf7eefa9d63a7e1): Update github action
+* [900d729](https://github.com/devFelicity/Bot-Frontend/commit/900d729c5b9df70a8caa56da2840f52a37159186): Update changelog
+* [12d0910](https://github.com/devFelicity/Bot-Frontend/commit/12d091081a7327e6bda488b401f45a70c5e2813a): add paginator to /recipes
+* [6db0329](https://github.com/devFelicity/Bot-Frontend/commit/6db0329e418839fa7b0102ec248d338159eb7bce): cleanup code
+* [600795e](https://github.com/devFelicity/Bot-Frontend/commit/600795edf1ef7389d843ddffd8e700c7b8bafc27): add vendor json for debugging
+* [9d599cd](https://github.com/devFelicity/Bot-Frontend/commit/9d599cdfa731366634d6789227fd4292d59e4f8d): prevent metrics crash and unrelated errors
+* [5f3c037](https://github.com/devFelicity/Bot-Frontend/commit/5f3c037bf8dc892187a1e478188b28f55ea667ea): move embed color to constant
+* [49d59ce](https://github.com/devFelicity/Bot-Frontend/commit/49d59ce3e0137fac385071591342c919db8d40e1): start ghosts of the deep loot table
+* [e904e44](https://github.com/devFelicity/Bot-Frontend/commit/e904e44817e9251b78287f3aeda71a985b5f01c6): fix rank
+* [9468cf0](https://github.com/devFelicity/Bot-Frontend/commit/9468cf0016d68fc6d67c06995f8042d7dcf6dc59): Update loot tables
+* [af0dd1b](https://github.com/devFelicity/Bot-Frontend/commit/af0dd1b567c7bcf2c54c7e565be93d16d45f181e): prevents metrics error
+* [ac55c60](https://github.com/devFelicity/Bot-Frontend/commit/ac55c608b486a311b29e747b2ba8a2662f202f01): Update dependencies
+* [8b66e49](https://github.com/devFelicity/Bot-Frontend/commit/8b66e49b13056a145e5de14a75a42e6e5aca68e5): Update CHANGELOG.md
+* [472055e](https://github.com/devFelicity/Bot-Frontend/commit/472055e08dad3d5ca62da17bdfe58678f186d74a): Update RecommendedRolls.cs
+* [bc39347](https://github.com/devFelicity/Bot-Frontend/commit/bc3934733a5487af1e6baf3fdbaed71ab4e1f6d9): add season of the deep craftables
+* [5d6458e](https://github.com/devFelicity/Bot-Frontend/commit/5d6458e989eecda1dd2bcb122d437f55a50360e0): fix case sensitive
+
+
 # Version: v8.0.0 (21-06-2023)
 * [f8ecc00](https://github.com/devFelicity/Bot-Frontend/commit/f8ecc004a6ac6e6b52c308536b8c4a165c139103): Bump Serilog from 2.12.0 to 3.0.0
 * [5da8076](https://github.com/devFelicity/Bot-Frontend/commit/5da807641c65b37c85be7f7f7b4c33e074a723f5): update changelog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,173 @@
+# Version: v8.0.0 (21-06-2023)
+
+* [f8ecc00](https://github.com/devFelicity/Bot-Frontend/commit/f8ecc004a6ac6e6b52c308536b8c4a165c139103): Bump Serilog from 2.12.0 to 3.0.0
+
+Bumps [Serilog](https://github.com/serilog/serilog) from 2.12.0 to 3.0.0.
+- [Release notes](https://github.com/serilog/serilog/releases)
+- [Changelog](https://github.com/serilog/serilog/blob/dev/CHANGES.md)
+- [Commits](https://github.com/serilog/serilog/compare/v2.12.0...v3.0.0)
+
+---
+updated-dependencies:
+- dependency-name: Serilog
+  dependency-type: direct:production
+  update-type: version-update:semver-major
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [5da8076](https://github.com/devFelicity/Bot-Frontend/commit/5da807641c65b37c85be7f7f7b4c33e074a723f5): update changelog
+* [afd40ae](https://github.com/devFelicity/Bot-Frontend/commit/afd40aed2d32eadc322da548c573097f6554ca18): add color to logging
+* [9e32977](https://github.com/devFelicity/Bot-Frontend/commit/9e329776cf26b91055dd5a00d121d50dc100cc3c): String optimisations
+* [a634ed7](https://github.com/devFelicity/Bot-Frontend/commit/a634ed7cda149e0291cd26169a377ee8c8f361a8): Bump DotNetBungieAPI from 2.10.0 to 2.11.0
+
+Bumps [DotNetBungieAPI](https://github.com/EndGameGl/DotNetBungieAPI) from 2.10.0 to 2.11.0.
+- [Release notes](https://github.com/EndGameGl/DotNetBungieAPI/releases)
+- [Commits](https://github.com/EndGameGl/DotNetBungieAPI/commits)
+
+---
+updated-dependencies:
+- dependency-name: DotNetBungieAPI
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [fd75996](https://github.com/devFelicity/Bot-Frontend/commit/fd75996c76208fcb0caebbb18089b6e0542bbca8): Bump Fergun.Interactive from 1.7.1 to 1.7.2
+
+Bumps [Fergun.Interactive](https://github.com/d4n3436/Fergun.Interactive) from 1.7.1 to 1.7.2.
+- [Release notes](https://github.com/d4n3436/Fergun.Interactive/releases)
+- [Commits](https://github.com/d4n3436/Fergun.Interactive/compare/v1.7.1...v1.7.2)
+
+---
+updated-dependencies:
+- dependency-name: Fergun.Interactive
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [01b340e](https://github.com/devFelicity/Bot-Frontend/commit/01b340e9c254d720fc01e7fdb399f421819f30d2): docs: update .all-contributorsrc [skip ci]
+* [38f0e91](https://github.com/devFelicity/Bot-Frontend/commit/38f0e916bee4937ab246505a64528983d8186f70): docs: update README.md [skip ci]
+* [ee135b9](https://github.com/devFelicity/Bot-Frontend/commit/ee135b944a5243139a62f98073b64c5465282d28): Fix up readme
+* [66a74b0](https://github.com/devFelicity/Bot-Frontend/commit/66a74b09c861367bd2521e55717ef19b5cc56c3f): Bump Sentry.AspNetCore from 3.33.0 to 3.33.1
+
+Bumps [Sentry.AspNetCore](https://github.com/getsentry/sentry-dotnet) from 3.33.0 to 3.33.1.
+- [Release notes](https://github.com/getsentry/sentry-dotnet/releases)
+- [Changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md)
+- [Commits](https://github.com/getsentry/sentry-dotnet/compare/3.33.0...3.33.1)
+
+---
+updated-dependencies:
+- dependency-name: Sentry.AspNetCore
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [78c73e1](https://github.com/devFelicity/Bot-Frontend/commit/78c73e16d1527b658da0e82387b81434045aa7de): Update .all-contributorsrc [skip ci]
+* [6b7aab8](https://github.com/devFelicity/Bot-Frontend/commit/6b7aab8b39e73603ba32337e7dd2e335c424f0b3): Update README.md [skip ci]
+* [a20f1fa](https://github.com/devFelicity/Bot-Frontend/commit/a20f1fa9f0a0ceb90c7a1c22c76d08ab1296c240): Bump Microsoft.EntityFrameworkCore from 7.0.5 to 7.0.7
+
+Bumps [Microsoft.EntityFrameworkCore](https://github.com/dotnet/efcore) from 7.0.5 to 7.0.7.
+- [Release notes](https://github.com/dotnet/efcore/releases)
+- [Commits](https://github.com/dotnet/efcore/compare/v7.0.5...v7.0.7)
+
+---
+updated-dependencies:
+- dependency-name: Microsoft.EntityFrameworkCore
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [b384f0d](https://github.com/devFelicity/Bot-Frontend/commit/b384f0d6b14aef362501e22b1889c282ade8bcb8): Bump Sentry.Serilog from 3.33.0 to 3.33.1
+
+Bumps [Sentry.Serilog](https://github.com/getsentry/sentry-dotnet) from 3.33.0 to 3.33.1.
+- [Release notes](https://github.com/getsentry/sentry-dotnet/releases)
+- [Changelog](https://github.com/getsentry/sentry-dotnet/blob/main/CHANGELOG.md)
+- [Commits](https://github.com/getsentry/sentry-dotnet/compare/3.33.0...3.33.1)
+
+---
+updated-dependencies:
+- dependency-name: Sentry.Serilog
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [773ac97](https://github.com/devFelicity/Bot-Frontend/commit/773ac97b8c41b9d53c1b0bbd72fece4a4e828b62): Fix LW weapons not appearing in crafted
+* [eeb1d2b](https://github.com/devFelicity/Bot-Frontend/commit/eeb1d2b0c2c197be0bdcaafe153451931fcc5cc2): update changelog
+* [c71e3cb](https://github.com/devFelicity/Bot-Frontend/commit/c71e3cb7776ea0ddd80f54a9fc68b819cc800f3e): fix incorrect urls in /support
+* [6aad3c5](https://github.com/devFelicity/Bot-Frontend/commit/6aad3c50d782efe84d588589ca5a04b9a7539ef1): fix dupe in crafted weapons
+* [5c5726c](https://github.com/devFelicity/Bot-Frontend/commit/5c5726c8dbf08365e0210fe615cd06096b273a14): Update README.md [skip ci]
+* [b11d536](https://github.com/devFelicity/Bot-Frontend/commit/b11d536fee872bb3ef3f0584df698c920b7ff7ab): Update FUNDING.yml [skip ci]
+* [f9c57fb](https://github.com/devFelicity/Bot-Frontend/commit/f9c57fb44edbaecc8caf0edd9a3a289ca62ae8cc): push changelog
+* [7c141bb](https://github.com/devFelicity/Bot-Frontend/commit/7c141bb90c62a43cdab4b5b3f74d2cafe0a3b57e): cleanup
+* [f10c602](https://github.com/devFelicity/Bot-Frontend/commit/f10c602c389e93ef8a8b7abade07413a564edac2): Remove redundant code
+* [abb0d34](https://github.com/devFelicity/Bot-Frontend/commit/abb0d34ced01dcfe8f25982e0a1f3224702fea33): Re-add showAll on /recipes
+* [cb6c690](https://github.com/devFelicity/Bot-Frontend/commit/cb6c6905d11c0227435a9e42625d3ec08b366725): correct Ada-1 description
+* [5a07114](https://github.com/devFelicity/Bot-Frontend/commit/5a07114340c9628518a33fef886f1cc7924cc30b): Added count to rarest emblems
+* [04e06b3](https://github.com/devFelicity/Bot-Frontend/commit/04e06b3de6bb6f1e303d75501d4c84b5fabaf4be): missed link change
+* [ad4f3bb](https://github.com/devFelicity/Bot-Frontend/commit/ad4f3bb29326cdcaa80c6a4b929762abd798d9d1): bump dependencies
+* [099c2f2](https://github.com/devFelicity/Bot-Frontend/commit/099c2f29487dc8b06bbbd697c140dffd99f0ce1c): add self-hosted assets
+* [cb0275e](https://github.com/devFelicity/Bot-Frontend/commit/cb0275e5cbe446e2c2f9357cba4b774d054c61e4): add support message
+* [7d886f8](https://github.com/devFelicity/Bot-Frontend/commit/7d886f8163de306f98f1584f7f6b1fcb7ef9d797): added GotD loot table
+* [ebe4ab3](https://github.com/devFelicity/Bot-Frontend/commit/ebe4ab34f9a5ec17ed9b811dd107a655b5cc0e7b): Fix new version issues
+* [a633f18](https://github.com/devFelicity/Bot-Frontend/commit/a633f18aa5f2489439e322d5bb9d2abffe9bf51b): update changelog [skip ci]
+* [724494d](https://github.com/devFelicity/Bot-Frontend/commit/724494db4572160030ee939a798f9a4be20cc7f8): fix downgrade issue
+* [07c9ec2](https://github.com/devFelicity/Bot-Frontend/commit/07c9ec2067ec325230f0e088bad5cd943aa62633): Bump DotNetBungieAPI from 2.9.0 to 2.10.0
+
+Bumps [DotNetBungieAPI](https://github.com/EndGameGl/DotNetBungieAPI) from 2.9.0 to 2.10.0.
+- [Release notes](https://github.com/EndGameGl/DotNetBungieAPI/releases)
+- [Commits](https://github.com/EndGameGl/DotNetBungieAPI/commits)
+
+---
+updated-dependencies:
+- dependency-name: DotNetBungieAPI
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>
+* [7b41abb](https://github.com/devFelicity/Bot-Frontend/commit/7b41abb0c6c284214c834574b4d83030f07cea35): Update dependabot.yml [skip-ci]
+* [ddafacd](https://github.com/devFelicity/Bot-Frontend/commit/ddafacd171b26c0e6e08e359b25d2523b15d17de): docs: update .all-contributorsrc [skip ci]
+* [18caba9](https://github.com/devFelicity/Bot-Frontend/commit/18caba9f802b1e5239e134120c2e8d835f00d205): docs: update README.md [skip ci]
+* [1405d98](https://github.com/devFelicity/Bot-Frontend/commit/1405d98adaf4704139ebce63ef66819542fd69f3): Update .all-contributorsrc
+* [cce0775](https://github.com/devFelicity/Bot-Frontend/commit/cce0775218a1acda390a63132b958a8da1dd7cd4): hopefully fixes cpu loop
+* [9a3c95c](https://github.com/devFelicity/Bot-Frontend/commit/9a3c95c2796e84abad2aa6dd9c73660f650bcdc4): forgor changelog
+* [0c71112](https://github.com/devFelicity/Bot-Frontend/commit/0c71112609df879e795f0064118fd6384e101602): Update to new auth url (also using as test)
+* [079fc25](https://github.com/devFelicity/Bot-Frontend/commit/079fc251e39d528676b7cf974e627c38ff8df4b6): use jq to make a payload
+* [f598f0d](https://github.com/devFelicity/Bot-Frontend/commit/f598f0d47c7b9e1fc7e224d99ee2c3c6b9fdd47c): attempt 412323234 at getting commit list to work
+* [f2eb7fa](https://github.com/devFelicity/Bot-Frontend/commit/f2eb7fa4f4aa9b3025f45e4edabd299700d239fd): quote marks are weird
+* [18676b9](https://github.com/devFelicity/Bot-Frontend/commit/18676b9394d75a9132a667367e3e07020ca77820): fix pr update json
+* [8a01efa](https://github.com/devFelicity/Bot-Frontend/commit/8a01efa9e407a02e523013b605bbed913de55cde): Update github action
+* [33ed80f](https://github.com/devFelicity/Bot-Frontend/commit/33ed80f313e8159c4c5dda3b22bad0004eb1c0e0): Revert "Update github action"
+
+This reverts commit 6768cdb3f6980301038ee3e4cbf7eefa9d63a7e1.
+* [6768cdb](https://github.com/devFelicity/Bot-Frontend/commit/6768cdb3f6980301038ee3e4cbf7eefa9d63a7e1): Update github action
+* [900d729](https://github.com/devFelicity/Bot-Frontend/commit/900d729c5b9df70a8caa56da2840f52a37159186): Update changelog
+* [12d0910](https://github.com/devFelicity/Bot-Frontend/commit/12d091081a7327e6bda488b401f45a70c5e2813a): add paginator to /recipes
+* [6db0329](https://github.com/devFelicity/Bot-Frontend/commit/6db0329e418839fa7b0102ec248d338159eb7bce): cleanup code
+* [600795e](https://github.com/devFelicity/Bot-Frontend/commit/600795edf1ef7389d843ddffd8e700c7b8bafc27): add vendor json for debugging
+* [9d599cd](https://github.com/devFelicity/Bot-Frontend/commit/9d599cdfa731366634d6789227fd4292d59e4f8d): prevent metrics crash and unrelated errors
+* [5f3c037](https://github.com/devFelicity/Bot-Frontend/commit/5f3c037bf8dc892187a1e478188b28f55ea667ea): move embed color to constant
+* [49d59ce](https://github.com/devFelicity/Bot-Frontend/commit/49d59ce3e0137fac385071591342c919db8d40e1): start ghosts of the deep loot table
+* [e904e44](https://github.com/devFelicity/Bot-Frontend/commit/e904e44817e9251b78287f3aeda71a985b5f01c6): fix rank
+* [9468cf0](https://github.com/devFelicity/Bot-Frontend/commit/9468cf0016d68fc6d67c06995f8042d7dcf6dc59): Update loot tables
+* [af0dd1b](https://github.com/devFelicity/Bot-Frontend/commit/af0dd1b567c7bcf2c54c7e565be93d16d45f181e): prevents metrics error
+* [ac55c60](https://github.com/devFelicity/Bot-Frontend/commit/ac55c608b486a311b29e747b2ba8a2662f202f01): Update dependencies
+* [8b66e49](https://github.com/devFelicity/Bot-Frontend/commit/8b66e49b13056a145e5de14a75a42e6e5aca68e5): Update CHANGELOG.md
+* [472055e](https://github.com/devFelicity/Bot-Frontend/commit/472055e08dad3d5ca62da17bdfe58678f186d74a): Update RecommendedRolls.cs
+* [bc39347](https://github.com/devFelicity/Bot-Frontend/commit/bc3934733a5487af1e6baf3fdbaed71ab4e1f6d9): add season of the deep craftables
+* [5d6458e](https://github.com/devFelicity/Bot-Frontend/commit/5d6458e989eecda1dd2bcb122d437f55a50360e0): fix case sensitive
+* [395b8fd](https://github.com/devFelicity/Bot-Frontend/commit/395b8fd01ec72fe833e6efdd6e806bce1e9b2979): update changelog
+* [43cc474](https://github.com/devFelicity/Bot-Frontend/commit/43cc4747b0166ddfcb174543a74a8ee19d5f168e): add emblem comparison for new manifests
+* [9071c1a](https://github.com/devFelicity/Bot-Frontend/commit/9071c1ac65219737e04cc9ea55949d6e8a007008): add status by DissObey
+* [f5c9eb2](https://github.com/devFelicity/Bot-Frontend/commit/f5c9eb2c23fa80371680eaeef311a1058d90c93c): add status
+* [5427889](https://github.com/devFelicity/Bot-Frontend/commit/54278895667f2ec734469c202ac25bd0a2a12abf): add `/pb raids`
+* [8944226](https://github.com/devFelicity/Bot-Frontend/commit/8944226449098354909acfa9d5f8f8b6b482237d): update changelog
+* [cda9e1e](https://github.com/devFelicity/Bot-Frontend/commit/cda9e1e18b06c41aa6358b8d818638ca6e41cabd): remove newlines from commit list
+* [d1f96b8](https://github.com/devFelicity/Bot-Frontend/commit/d1f96b8a48ac6bb6407536cea3791d6958393c28): update color to fit new logo
+* [ae808cc](https://github.com/devFelicity/Bot-Frontend/commit/ae808ccaa1d77e07076aec329f6b9a157770fa41): add metrics
+* [273e42c](https://github.com/devFelicity/Bot-Frontend/commit/273e42ca066ec84a151d6f03b32b579668fd4e42): code cleanup
+* [39d10a4](https://github.com/devFelicity/Bot-Frontend/commit/39d10a4e51a4308dcd8f39b47febbaa5cdea1938): Update publish.yml

--- a/Felicity/Util/BotVariables.cs
+++ b/Felicity/Util/BotVariables.cs
@@ -11,7 +11,7 @@ public static class BotVariables
     public const string BungieBaseUrl = "https://www.bungie.net/";
 
     internal const string ErrorMessage = $"You can report this error either in our [Support Server]({DiscordInvite}) " +
-                                         "or by creating a new [Issue](https://github.com/MoonieGZ/FelicityOne/issues/new?assignees=axsLeaf&labels=bug&template=bug-report.md&title=) on GitHub.";
+                                         "or by creating a new [Issue](https://github.com/devFelicity/FelicityOne/issues/new?assignees=axsLeaf&labels=bug&template=bug-report.md&title=) on GitHub.";
 
     internal static bool IsDebug;
     internal static string? Version;
@@ -29,8 +29,8 @@ public static class BotVariables
         {
             using var httpClient = new HttpClient();
             var s = await httpClient.GetStringAsync(
-                "https://raw.githubusercontent.com/MoonieGZ/FelicityOne/main/CHANGELOG.md");
-            Version = s.Split("## [")[1].Split("]")[0];
+                "https://raw.githubusercontent.com/devFelicity/FelicityOne/main/CHANGELOG.md");
+            Version = s.Split("# Version: ")[1].Split(" (")[0];
         }
     }
 


### PR DESCRIPTION
- Bump Fergun.Interactive from 1.7.1 to 1.7.2
- Bump Serilog from 2.12.0 to 3.0.0
- Bump DotNetBungieAPI from 2.10.0 to 2.11.0
- fix(version): update version checker to new format
